### PR TITLE
Standardise on 2-space spacing and add semicolons as an alternative separator

### DIFF
--- a/orng.c
+++ b/orng.c
@@ -335,7 +335,7 @@ int main(int argc, char *argv[])
     cmd = strtok(line, " ");
 
     num_args = 0;
-    while ((arg = strtok(NULL, " \n")) != NULL) {
+    while ((arg = strtok(NULL, " \n;")) != NULL) {
       assert(num_args < MAX_COMMAND_ARGS);
 
       args[num_args] = atoi(arg);


### PR DESCRIPTION
`git diff -w` seems to show nothing, so this should just be whitespace changes.

Semicolons will be useful for treating a series of steps as an atomic action (e.g. actually close the current app by pressing home key long press then drag up).
