### PR TITLE
Fix pie error for Android 4.1 and above

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,8 +7,8 @@ FLOAT_ABI=@FLOAT_ABI@
 AGCC=$(NDKROOT)/toolchains/arm-linux-androideabi-*/prebuilt/$(UNAME)/bin/arm-linux-androideabi-gcc
 
 ACPPFLAGS := -DANDROID -DOS_ANDROID -DNDK_BUILD
-ACFLAGS := -march=$(ARCH) -mfpu=$(FPU) -mfloat-abi=$(FLOAT_ABI) --sysroot $(NDKROOT)/platforms/android-9/arch-arm -fPIC -mandroid
-ALDFLAGS :=--sysroot $(NDKROOT)/platforms/android-9/arch-arm -fPIC -mandroid
+ACFLAGS := -march=$(ARCH) -mfpu=$(FPU) -mfloat-abi=$(FLOAT_ABI) --sysroot $(NDKROOT)/platforms/android-9/arch-arm -fPIC -mandroid -fPIE -pie
+ALDFLAGS :=--sysroot $(NDKROOT)/platforms/android-9/arch-arm -fPIC -mandroid -fPIE -pie
 
 
 PROGRAMS := mkdevinfo \

--- a/Makefile.in
+++ b/Makefile.in
@@ -4,11 +4,12 @@ ARCH=@ARCH@
 FPU=@FPU@
 FLOAT_ABI=@FLOAT_ABI@
 
-AGCC=$(NDKROOT)/toolchains/arm-linux-androideabi-4.8/prebuilt/$(UNAME)/bin/arm-linux-androideabi-gcc
+AGCC=$(NDKROOT)/toolchains/arm-linux-androideabi-*/prebuilt/$(UNAME)/bin/arm-linux-androideabi-gcc
 
 ACPPFLAGS := -DANDROID -DOS_ANDROID -DNDK_BUILD
 ACFLAGS := -march=$(ARCH) -mfpu=$(FPU) -mfloat-abi=$(FLOAT_ABI) --sysroot $(NDKROOT)/platforms/android-9/arch-arm -fPIC -mandroid
 ALDFLAGS :=--sysroot $(NDKROOT)/platforms/android-9/arch-arm -fPIC -mandroid
+
 
 PROGRAMS := mkdevinfo \
             orng \


### PR DESCRIPTION
Thanks for great tool!

PIE (Position Independent Executable) support was added in Android 4.1
> https://source.android.com/security/enhancements/enhancements41

Thus running orng on device without PIE would cause

```error: only position independent executables (PIE) are supported.```
